### PR TITLE
Set the body css to white

### DIFF
--- a/styles/branding.css
+++ b/styles/branding.css
@@ -7,6 +7,7 @@ body {
 	margin-left: auto;
 	margin-right: auto;
 	color: #000;
+	background-color: white;
 }
 h1 {
 	font-family: 'Segoe UI' , 'Lucida Grande' , Verdana, Arial, Helvetica, sans-serif;


### PR DESCRIPTION
Player's often use the steam overlay for quick reference, the default background-color in steam web browser is grey or black. This force sets the background color to white.